### PR TITLE
2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.2
+- custom_inherit.store no longer inherits from `dict`. Fixes bug in which `store.update` could be used
+to circumvent the type-checking that the store enforces.
+
 ### 2.0.1
 - Numpy-style section delimiters was fixed so that they are the appropriate length, and thus compatible with the numpy-style for sphinx.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Documentation is available via `help(custom_inherit)`.
 
 ```python
 custom_inherit.DocInheritMeta(style="parent", abstract_base_class=False)
-    """ Returns the DocInheritor metaclass of the specified style.
+    """ A metaclass that merges the respective docstrings of a parent class and of its child, along with their
+        properties, methods (including classmethod, staticmethod, decorated methods).
 
         Parameters
         ----------
@@ -204,7 +205,7 @@ custom_inherit.DocInheritMeta(style="parent", abstract_base_class=False)
 
 custom_inherit.doc_inherit(parent, style="parent"):
     """ Returns a function/method decorator that, given `parent`, updates the docstring of the decorated
-        function/method based on the specified style and `parent`.
+        function/method based on the specified style and the corresponding attribute of `parent`.
 
         Parameters
         ----------

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -136,7 +136,8 @@ def remove_style(style):
 
 
 def DocInheritMeta(style="parent", abstract_base_class=False):
-    """ Returns the DocInheritor metaclass of the specified style.
+    """ A metaclass that merges the respective docstrings of a parent class and of its child, along with their
+        properties, methods (including classmethod, staticmethod, decorated methods).
 
         Parameters
         ----------
@@ -165,7 +166,7 @@ def DocInheritMeta(style="parent", abstract_base_class=False):
 
 def doc_inherit(parent, style="parent"):
     """ Returns a function/method decorator that, given `parent`, updates the docstring of the decorated
-        function/method based on the specified style and `parent`.
+        function/method based on the specified style and the corresponding attribute of `parent`.
 
         Parameters
         ----------

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -25,6 +25,10 @@ def _check_style_function(style_func):
 class _Store(dict):
     """ A dictionary that stores the styles available for the doc-inheritance metaclass and decorator,
        respectively."""
+
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+
     def __str__(self):
         out_str = "The available stored styles are: "
         styles = "\n".join("\t- " + style for style in sorted(self.keys()))
@@ -42,8 +46,8 @@ class _Store(dict):
         try:
             _check_style_function(style_func)
         except TypeError:
-            raise TypeError("The style store only stores functions (callables) of the form:\
-             \n\tstyle_func(Optional[str], Optional[str]) -> Optional[str]")
+            raise TypeError("The style store only stores callables (callables) of the form: "
+                            "\n\tstyle_func(Optional[str], Optional[str]) -> Optional[str]")
         super(_Store, self).__setitem__(style_name, style_func)
 
     def __getitem__(self, item):
@@ -59,9 +63,9 @@ class _Store(dict):
         except KeyError:
             try:
                 _check_style_function(item)
+                return item
             except TypeError:
                 raise TypeError("Either a valid style name or style-function must be specified")
-        return item
 
     def update(self, *args, **kwargs):
         if len(args) > 1:

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -33,7 +33,8 @@ class _Store(dict):
             style_func: Callable[[Optional[str], Optional[str]], Optional[str]]
                 The style function that merges two docstrings into a single docstring."""
         try:
-            style_func("", "")
+            if not (isinstance(style_func("", ""), basestring) or style_func("", "") is None):
+                raise TypeError
         except TypeError:
             raise TypeError("The style store only stores functions (callables) of the form:\
              \n\tstyle_func(Optional[str], Optional[str]) -> Optional[str]")
@@ -51,7 +52,8 @@ class _Store(dict):
             return super(_Store, self).__getitem__(item)
         except KeyError:
             try:
-                item("", "")
+                if not (isinstance(item("", ""), basestring) or item("", "") is None):
+                    raise TypeError
             except TypeError:
                 raise TypeError("Either a valid style name or style-function must be specified")
         return item

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -12,7 +12,7 @@ except NameError:
 
 
 __all__ = ["DocInheritMeta", "doc_inherit", "store", "add_style", "remove_style"]
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 
 def _check_style_function(style_func):

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -95,12 +95,6 @@ class _Store(object):
         for key, value in dict(*args, **kwargs).items():
             self[key] = value
 
-    def setdefault(self, key, value=None):
-        """  D.setdefault(k[,d]) -> D.get(k,d), also set D[k]=d if k not in D"""
-        if key not in self:
-            self[key] = value
-        return self[key]
-
     def values(self):
         """ D.values() -> an object providing a view on D's values."""
         return self._store.values()


### PR DESCRIPTION
- store no longer inherits from `dict`. Prevents type check circumvention via `update`
- updated documentation