### PR TITLE
successively merge along mro for class docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.2.0 (3/27/2018)
+- Previously, the class docstring inherited only from the most immediate parent class that has a docstring. Now,
+the "parent" docstring is accumulated by successively merging the accumulated string with the docstring of
+the next-parent in the mro. This accumulated docstring is then merged with the docstring of the present class. This permits sensible class-docstring inheritance in cases of multiple inheritance.
+- Minor code refactoring.
+
 ### 2.1.1 (2/15/2017)
 - Added compatibility with Python 3.3 & 3.4
 

--- a/custom_inherit/__init__.py
+++ b/custom_inherit/__init__.py
@@ -11,7 +11,7 @@ except NameError:
 
 
 __all__ = ["DocInheritMeta", "doc_inherit", "store", "add_style", "remove_style"]
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 
 
 def _check_style_function(style_func):

--- a/tests/metaclass_test.py
+++ b/tests/metaclass_test.py
@@ -190,7 +190,8 @@ def test_property2():
 
 
 def test_class_docstring():
-    class Parent(metaclass=DocInheritMeta(style="numpy")):
+    @add_metaclass(DocInheritMeta(style=style))
+    class Parent:
         """
         Parent class.
 

--- a/tests/metaclass_test.py
+++ b/tests/metaclass_test.py
@@ -186,3 +186,31 @@ def test_staticmethod2():
 def test_property2():
     assert isinstance(Kid2.prop, property)
     assert getdoc(Kid2.prop) == "valid"
+
+
+
+def test_class_docstring():
+    class Parent(metaclass=DocInheritMeta(style="numpy")):
+        """
+        Parent class.
+
+        Returns
+        -------
+        foo
+        """
+
+    class Mixin:
+        """
+        This is mixin which does something.
+
+        """
+
+    class Child(Mixin, Parent):
+        """
+        Attributes
+        ----------
+        bar
+        """
+
+    assert getdoc(Child) == \
+           'This is mixin which does something.\n\nAttributes\n----------\nbar\n\nReturns\n-------\nfoo'

--- a/tests/metaclass_test.py
+++ b/tests/metaclass_test.py
@@ -190,8 +190,8 @@ def test_property2():
 
 
 def test_class_docstring():
-    @add_metaclass(DocInheritMeta(style=style))
-    class Parent:
+    @add_metaclass(DocInheritMeta(style="numpy"))
+    class Parent(object):
         """
         Parent class.
 
@@ -200,7 +200,7 @@ def test_class_docstring():
         foo
         """
 
-    class Mixin:
+    class Mixin(object):
         """
         This is mixin which does something.
 


### PR DESCRIPTION
Previously, the class docstring inherited only from the most immediate parent class that has a docstring. 

Now, the "parent" docstring is accumulated by successively merging the accumulated string with the docstring of